### PR TITLE
Remove `TensorNoiseCommon.device` field

### DIFF
--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -313,7 +313,6 @@ class SkrampleWrapperScheduler:
                     schedule,
                     seeds,
                     dtype=torch.float32,
-                    device=torch.device("cpu"),
                 )
 
             noise = self._noise_generator.generate(step).to(dtype=self.compute_scale, device=model_output.device)


### PR DESCRIPTION
It was effectively non-functional with `Generator` already containing a device. All it was doing was causing device errors.

Not going to consider this a breaking change because it was already broken.