### PR TITLE
Linear: Fix start/end not being used, allow non-subnormal, sd1/xl compat

### DIFF
--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -105,6 +105,14 @@ def parse_diffusers_config(
         else:
             schedule = scheduling.Scaled
 
+    # Adjust sigma_start to match scaled beta for sd1/xl
+    if "sigma_start" not in remapped and predictor is not sampling.FLOW and issubclass(schedule, scheduling.Linear):
+        scaled_keys = [f.name for f in dataclasses.fields(scheduling.Scaled)]
+        sigma_start: float = (
+            scheduling.Scaled(**{k: v for k, v in remapped.items() if k in scaled_keys}).sigmas(1).item()
+        )
+        remapped["sigma_start"] = math.sqrt(sigma_start)
+
     if not schedule_modifier:
         schedule_modifier = remapped.pop("skrample_modifier", None)
 


### PR DESCRIPTION
While the results don't look good, Linear and subclasses as the schedule for sd1/xl/etc should now produce usable images instead of nan/noise.

Done by just unscaling the start sigma using sqrt(). Really unscientific