### PR TITLE
Parse Diffusers Scheduler Classes

### DIFF
--- a/.github/workflows/master_ci.yml
+++ b/.github/workflows/master_ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - run: uv venv --python 3.12  # torch index breaks sync
       - name: Install
-        run: uv pip install .[dev] --extra-index-url https://download.pytorch.org/whl/cpu --resolution lowest-direct
+        run: uv pip install .[test] --extra-index-url https://download.pytorch.org/whl/cpu --resolution lowest-direct
 
       - name: Ruff Check
         if: '!cancelled()'

--- a/.github/workflows/master_ci.yml
+++ b/.github/workflows/master_ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: uv venv --python 3.13
       - name: Install
-        run: uv pip install .[dev] --extra-index-url https://download.pytorch.org/whl/cpu -U
+        run: uv pip install .[test] --extra-index-url https://download.pytorch.org/whl/cpu -U
 
       - name: Ruff Check
         if: '!cancelled()'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ Change `diffusers.parse_diffusers_config` to take config as dict instead of **co
 Moved customization properties from all pytorch.noise classes into their own property structs,
 guarded by static type analysis. Should allow easily configuring the rng while guaranteeing state drop.
 
-Brownian was previously incorectly stepping in reverse. This was remedied, with reverse being made a new prop
+### Additions
+Linear() can now adjust presented `.subnormal` property
 
-...
+Added diffusers class -> sampler map. Passing `sampler` to diffuser config parsing is now optional.
+
+### Fixes
+Linear() and derivatives now respect sigma_start and sigma_end properly
+
+Brownian now takes steps in proper order. Old behavior available via `.reverse` prop
 
 ## 0.1.1
 Remove `TensorNoiseCommon.device` field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Linear() can now adjust presented `.subnormal` property
 
 Added diffusers class -> sampler map. Passing `sampler` to diffuser config parsing is now optional.
 
+More diffuserse config mappings
+
 ### Fixes
 Linear() and derivatives now respect sigma_start and sigma_end properly
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,18 @@ pytorch = ["torch>=2.5"]
 
 all = ["skrample[beta-schedule,brownian-noise,diffusers-wrapper,pytorch]"]
 
-dev = [
+test = [
     "skrample[all]",
-    "accelerate>=1.3",
     "diffusers>=0.32",
-    "protobuf>=5.29",
     "pyright>=1.1.397",
     "pytest>=8.3",
     "ruff>=0.11",
+]
+
+dev = [
+    "skrample[test]",
+    "accelerate>=1.3",
+    "protobuf>=5.29",
     "sentencepiece>=0.2",
     "transformers>=4.48",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ test = [
     "pyright>=1.1.397",
     "pytest>=8.3",
     "ruff>=0.11",
+    "transformers>=4.48",
 ]
 
 dev = [
@@ -32,7 +33,6 @@ dev = [
     "accelerate>=1.3",
     "protobuf>=5.29",
     "sentencepiece>=0.2",
-    "transformers>=4.48",
 ]
 
 [tool.ruff]

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -205,7 +205,7 @@ class SkrampleWrapperScheduler[T: TensorNoiseProps | None]:
         schedule_modifier: type[ScheduleModifier] | None = None,
         predictor: PREDICTOR | None = None,
         noise_props: N | None = None,
-        compute_scale: torch.dtype | None = None,
+        compute_scale: torch.dtype | None = torch.float32,
         sampler_props: dict[str, Any] = {},
         schedule_props: dict[str, Any] = {},
         schedule_modifier_props: dict[str, Any] = {},

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 
 DIFFUSERS_CLASS_MAP: dict[str, tuple[type[SkrampleSampler], dict[str, Any]]] = {
+    "DDIMScheduler": (sampling.Euler, {}),
+    "DDPMScheduler": (sampling.Euler, {"add_noise": True}),
     "DPMSolverMultistepScheduler": (sampling.DPM, {}),
     "DPMSolverSDEScheduler": (sampling.DPM, {"add_noise": True}),
     "EulerAncestralDiscreteScheduler": (sampling.Euler, {"add_noise": True}),
@@ -52,6 +54,11 @@ DIFFUSERS_VALUE_MAP: dict[tuple[str, Any], tuple[str, Any]] = {
     ("timestep_spacing", "leading"): ("uniform", False),
     ("timestep_spacing", "linspace"): ("uniform", True),
     ("timestep_spacing", "trailing"): ("uniform", True),
+    # sampling.StochasticSampler
+    ("algorithm_type", "dpmsolver"): ("add_noise", False),
+    ("algorithm_type", "dpmsolver++"): ("add_noise", False),
+    ("algorithm_type", "sde-dpmsolver"): ("add_noise", True),
+    ("algorithm_type", "sde-dpmsolver++"): ("add_noise", True),
     # Complex types
     ("prediction_type", "epsilon"): ("skrample_predictor", sampling.EPSILON),
     ("prediction_type", "flow"): ("skrample_predictor", sampling.FLOW),

--- a/tests/diffusers_map.py
+++ b/tests/diffusers_map.py
@@ -1,0 +1,103 @@
+from diffusers.configuration_utils import ConfigMixin
+from diffusers.schedulers.scheduling_ddim import DDIMScheduler
+from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
+from diffusers.schedulers.scheduling_dpmsolver_multistep import DPMSolverMultistepScheduler
+from diffusers.schedulers.scheduling_dpmsolver_sde import DPMSolverSDEScheduler
+from diffusers.schedulers.scheduling_euler_ancestral_discrete import EulerAncestralDiscreteScheduler
+from diffusers.schedulers.scheduling_euler_discrete import EulerDiscreteScheduler
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
+from diffusers.schedulers.scheduling_ipndm import IPNDMScheduler
+from diffusers.schedulers.scheduling_unipc_multistep import UniPCMultistepScheduler
+from testing_common import FLOW_CONFIG, SCALED_CONFIG
+
+from skrample.diffusers import SkrampleWrapperScheduler
+from skrample.sampling import DPM, EPSILON, FLOW, IPNDM, VELOCITY, Euler, UniPC
+from skrample.scheduling import Flow, Scaled
+
+
+def check_wrapper(wrapper: SkrampleWrapperScheduler, scheduler: ConfigMixin, params: list[str] = []) -> None:
+    a, b = wrapper, SkrampleWrapperScheduler.from_diffusers_config(scheduler)
+    a.fake_config = b.fake_config
+    assert a == b, " | ".join([type(scheduler).__name__] + [str(p) for p in params])
+
+
+def test_dpm() -> None:
+    for algo, noise in [
+        ("dpmsolver", False),
+        ("dpmsolver++", False),
+        ("sde-dpmsolver", True),
+        ("sde-dpmsolver++", True),
+    ]:
+        for uniform, spacing in [(False, "leading"), (True, "trailing")]:
+            for skpred, dfpred in [(EPSILON, "epsilon"), (VELOCITY, "v_prediction")]:
+                for order in range(1, 4):
+                    check_wrapper(
+                        SkrampleWrapperScheduler(
+                            DPM(predictor=skpred, add_noise=noise, order=order),
+                            Scaled(uniform=uniform),
+                        ),
+                        DPMSolverMultistepScheduler.from_config(  # type: ignore ConfigMixin
+                            SCALED_CONFIG
+                            | {
+                                "prediction_type": dfpred,
+                                "solver_order": order,
+                                "timestep_spacing": spacing,
+                                "algorithm_type": algo,
+                                "final_sigmas_type": "sigma_min",  # for non ++ to not err
+                            }
+                        ),
+                        [algo, spacing, dfpred, f"o{order}"],
+                    )
+
+    check_wrapper(
+        SkrampleWrapperScheduler(DPM(predictor=FLOW, order=2), Flow()),
+        DPMSolverMultistepScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
+    )
+
+
+def test_euler() -> None:
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(), Scaled(uniform=False)),
+        EulerDiscreteScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(add_noise=True), Scaled(uniform=False)),
+        EulerAncestralDiscreteScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(predictor=FLOW), Flow()),
+        FlowMatchEulerDiscreteScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
+    )
+
+
+def test_ipndm() -> None:
+    check_wrapper(
+        SkrampleWrapperScheduler(IPNDM(), Scaled(uniform=False)),
+        IPNDMScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+
+
+def test_unipc() -> None:
+    check_wrapper(
+        SkrampleWrapperScheduler(UniPC(order=2), Scaled(uniform=False)),
+        UniPCMultistepScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(UniPC(predictor=FLOW, order=2), Flow()),
+        UniPCMultistepScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
+    )
+
+
+def test_alias() -> None:
+    check_wrapper(
+        SkrampleWrapperScheduler(DPM(add_noise=True), Scaled(uniform=False)),
+        DPMSolverSDEScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(), Scaled(uniform=False)),
+        DDIMScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(add_noise=True), Scaled(uniform=False)),
+        DDPMScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
+    )

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -6,9 +6,11 @@ from huggingface_hub import hf_hub_download
 FLOW_CONFIG = {
     "base_image_seq_len": 256,
     "base_shift": 0.5,
+    "flow_shift": 3.0,
     "max_image_seq_len": 4096,
     "max_shift": 1.15,
     "num_train_timesteps": 1000,
+    "prediction_type": "flow_prediction",
     "shift": 3.0,
     "use_dynamic_shifting": True,
 }


### PR DESCRIPTION
Can now just pass the whole scheduler into `from_diffusers_config` and get a full wrapper back. Should 1:1 match diffusers for most sd/flux schedulers.