### PR TITLE
Add SigmoidCDF schedule, Refactor Flow() -> FlowShift, Refactor ScheduleModifier Handling in `skrample.diffusers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ Change `diffusers.parse_diffusers_config` to take config as dict instead of **co
 Moved customization properties from all pytorch.noise classes into their own property structs,
 guarded by static type analysis. Should allow easily configuring the rng while guaranteeing state drop.
 
+Replace Flow() schedule with FlowShift() schedule modifier.
+
+Updated `parse_diffusers_config` and `from_diffusers_config` to properly handle multiple modifiers
+
 ### Additions
 Linear() can now adjust presented `.subnormal` property
 
 Added diffusers class -> sampler map. Passing `sampler` to diffuser config parsing is now optional.
 
 More diffuserse config mappings
+
+SigmaCDF() schedule
+
+`scripts/plot_schedules.py` for visualising noise schedules
 
 ### Fixes
 Linear() and derivatives now respect sigma_start and sigma_end properly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 beta-schedule = ["scipy>=1.12"]
+cdf-schedule = ["scipy>=1.12"]
 brownian-noise = ["torchsde>=0.2.6"]
 diffusers-wrapper = ["torch>=2.5"]
 pytorch = ["torch>=2.5"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dev = [
     "sentencepiece>=0.2",
 ]
 
+scripts = [
+    "skrample[all]",
+    "matplotlib>=3.10.1",
+]
+
 [tool.ruff]
 line-length = 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,13 @@ pytorch = ["torch>=2.5"]
 
 all = ["skrample[beta-schedule,brownian-noise,diffusers-wrapper,pytorch]"]
 
-test = [
+scripts = [
     "skrample[all]",
+    "matplotlib>=3.10.1",
+]
+
+test = [
+    "skrample[scripts]",
     "diffusers>=0.32",
     "pyright>=1.1.397",
     "pytest>=8.3",
@@ -34,11 +39,6 @@ dev = [
     "accelerate>=1.3",
     "protobuf>=5.29",
     "sentencepiece>=0.2",
-]
-
-scripts = [
-    "skrample[all]",
-    "matplotlib>=3.10.1",
 ]
 
 [tool.ruff]

--- a/scripts/plot_schedules.py
+++ b/scripts/plot_schedules.py
@@ -16,9 +16,9 @@ SCHEDULES: dict[str, scheduling.ScheduleCommon | scheduling.ScheduleModifier] = 
     "zsnr": scheduling.ZSNR(),
     "linear": scheduling.Linear(),
     "sigcdf": scheduling.SigmoidCDF(),
-    "flow": scheduling.Flow(),
+    "flow": scheduling.FlowShift(scheduling.Linear()),
     "flowsig": scheduling.FlowShift(scheduling.SigmoidCDF()),
-    "flow_mu": scheduling.Flow(mu=1),
+    "flow_mu": scheduling.FlowShift(scheduling.Linear(), mu=1),
 }
 
 MODIFIERS: dict[str, type[scheduling.ScheduleModifier] | None] = {

--- a/scripts/plot_schedules.py
+++ b/scripts/plot_schedules.py
@@ -82,7 +82,7 @@ parser.add_argument(
     type=str,
     choices=list(SCHEDULES.keys()),
     nargs="+",
-    default=["scaled_uniform", "flow"],
+    default=["scaled_uniform", "sigcdf"],
 )
 parser.add_argument(
     "--modifier",
@@ -90,7 +90,7 @@ parser.add_argument(
     type=str,
     choices=list(MODIFIERS.keys()),
     nargs="+",
-    default=["none"],
+    default=["none", "flow"],
 )
 parser.add_argument(
     "--modifier_2",

--- a/scripts/plot_schedules.py
+++ b/scripts/plot_schedules.py
@@ -1,0 +1,141 @@
+#! /usr/bin/env python
+
+from argparse import ArgumentParser
+from collections.abc import Generator
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.typing import NDArray
+
+import skrample.scheduling as scheduling
+
+SCHEDULES: dict[str, scheduling.ScheduleCommon] = {
+    "scaled": scheduling.Scaled(uniform=False),
+    "scaled_uniform": scheduling.Scaled(),
+    "zsnr": scheduling.ZSNR(),
+    "linear": scheduling.Linear(),
+    "flow": scheduling.Flow(),
+    "flow_mu": scheduling.Flow(mu=1),
+}
+
+MODIFIERS: dict[str, type[scheduling.ScheduleModifier] | None] = {
+    "beta": scheduling.Beta,
+    "exponential": scheduling.Exponential,
+    "karras": scheduling.Karras,
+    "none": None,
+}
+
+OKLAB_XYZ_M1 = np.array(
+    [
+        [0.41217385, 0.21187214, 0.08831541],
+        [0.53629746, 0.68074768, 0.28186631],
+        [0.05146303, 0.10740646, 0.63026345],
+    ]
+)
+OKLAB_M2 = np.array(
+    [
+        [0.2104542553, 1.9779984951, 0.0259040371],
+        [0.7936177850, -2.4285922050, 0.7827717662],
+        [-0.0040720468, 0.4505937099, -0.8086757660],
+    ]
+)
+
+
+def spowf(array: NDArray[np.float64], power: int | float | list[int | float]) -> NDArray[np.float64]:
+    return np.copysign(np.abs(array) ** power, array)
+
+
+def oklch_to_srgb(array: NDArray[np.float64]) -> list[float]:
+    oklab = np.stack(
+        [array[0], array[1] * np.cos(np.deg2rad(array[2])), array[1] * np.sin(np.deg2rad(array[2]))],
+        axis=0,
+    )
+    lrgb = spowf((oklab @ np.linalg.inv(OKLAB_M2)), 3) @ np.linalg.inv(OKLAB_XYZ_M1)
+    srgb = spowf(lrgb, 1 / 2.2)
+    return srgb.clip(0, 1).tolist()  # type: ignore
+
+
+def colors(hue_steps: int) -> Generator[list[float]]:
+    for offset in 0, 1:
+        for lightness, chroma in [
+            (0.6, 0.6),
+            (0.8, 0.4),
+            (0.4, 0.4),
+            (0.8, 0.8),
+            (0.4, 0.8),
+        ]:
+            lighness_actual = lightness * (0.9 - 0.25) + 0.25  # offset by approximate quantiles of srgb clip
+            chroma_actual = chroma * 0.25
+            for hue in range(15 + int(offset * 360 / hue_steps / 2), 360, int(360 / hue_steps)):
+                yield oklch_to_srgb(np.array([lighness_actual, chroma_actual, hue], dtype=np.float64))
+
+
+parser = ArgumentParser()
+parser.add_argument("file", type=Path)
+parser.add_argument("--steps", type=int, default=20)
+parser.add_argument(
+    "--schedule",
+    "-s",
+    type=str,
+    choices=list(SCHEDULES.keys()),
+    nargs="+",
+    default=["scaled_uniform", "flow"],
+)
+parser.add_argument(
+    "--modifier",
+    "-m",
+    type=str,
+    choices=list(MODIFIERS.keys()),
+    nargs="+",
+    default=["none"],
+)
+
+args = parser.parse_args()
+
+width, height = 12, 6
+plt.figure(figsize=(width, height), facecolor="black", edgecolor="white")
+
+COLORS = colors(6)
+for mod_name in args.modifier:
+    for sched_name in args.schedule:
+        schedule = SCHEDULES[sched_name]
+        modifier = MODIFIERS[mod_name]
+        base = schedule.base_timesteps
+
+        if modifier is not None:
+            composed = modifier(schedule)
+            label: str = sched_name + "_" + mod_name
+        else:
+            composed = schedule
+            label = sched_name
+
+        label = " ".join([s.capitalize() for s in label.split("_")])
+
+        data = np.concatenate([composed.schedule(args.steps), [[0, 0]]], dtype=np.float64)
+
+        timesteps = data[:, 0] / base
+        sigmas = data[:, 1] / data[:, 1].max()
+
+        plt.plot(timesteps, label=label + " Timesteps", marker="+", color=next(COLORS))
+        if not np.allclose(timesteps, sigmas, atol=1e-2):
+            plt.plot(sigmas, label=label + " Sigmas", marker="+", color=next(COLORS))
+
+plt.xlabel("Step")
+plt.ylabel("Normalized Values")
+plt.title("Skrample Schedules")
+ax = plt.gca()
+ax.set(facecolor="black")
+ax.grid(color="white")
+
+ax.tick_params(axis="both", which="both", color="white")
+
+ax.xaxis.label.set_color("white")
+ax.yaxis.label.set_color("white")
+ax.title.set_color("white")
+
+[v.set_color("white") for v in list(ax.spines.values()) + ax.get_xticklabels() + ax.get_yticklabels()]
+
+ax.legend(facecolor="black", labelcolor="white", edgecolor="gray")
+
+plt.savefig(args.file, dpi=max(1920 / width, 1080 / height))

--- a/skrample/common.py
+++ b/skrample/common.py
@@ -1,0 +1,50 @@
+import enum
+import math
+from collections.abc import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@enum.unique
+class MergeStrategy(enum.StrEnum):  # str for easy UI options
+    Ours = enum.auto()
+    Theirs = enum.auto()
+    After = enum.auto()
+    Before = enum.auto()
+    UniqueAfter = enum.auto()
+    UniqueBefore = enum.auto()
+
+    def merge[T](self, ours: list[T], theirs: list[T], cmp: Callable[[T, T], bool] = lambda a, b: a == b) -> list[T]:
+        match self:
+            case MergeStrategy.Ours:
+                return ours
+            case MergeStrategy.Theirs:
+                return theirs
+            case MergeStrategy.After:
+                return ours + theirs
+            case MergeStrategy.Before:
+                return theirs + ours
+            case MergeStrategy.UniqueAfter:
+                return ours + [i for i in theirs if not any(map(cmp, ours, [i] * len(theirs)))]
+            case MergeStrategy.UniqueBefore:
+                return theirs + [i for i in ours if not any(map(cmp, theirs, [i] * len(ours)))]
+
+
+def safe_log(x: float) -> float:
+    try:
+        return math.log(x)
+    except ValueError:
+        return math.inf
+
+
+def normalize(regular_array: NDArray[np.float64], start: float = 1, end: float = 0) -> NDArray[np.float64]:
+    return (regular_array - end) / (start - end)
+
+
+def regularize(normal_array: NDArray[np.float64], start: float = 1, end: float = 0) -> NDArray[np.float64]:
+    return normal_array * (start - end) + end
+
+
+def sigmoid(array: NDArray[np.float64]) -> NDArray[np.float64]:
+    return 1 / (1 + np.exp(array))

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -136,9 +136,9 @@ def parse_diffusers_config(
     # Adjust sigma_start to match scaled beta for sd1/xl
     if "sigma_start" not in remapped and predictor is not sampling.FLOW and issubclass(schedule, scheduling.Linear):
         scaled_keys = [f.name for f in dataclasses.fields(scheduling.Scaled)]
-        sigma_start: float = (
-            scheduling.Scaled(**{k: v for k, v in remapped.items() if k in scaled_keys}).sigmas(1).item()
-        )
+        scaled = scheduling.Scaled(**{k: v for k, v in remapped.items() if k in scaled_keys})
+        scaled.uniform = True  # non-uniform misses a whole timestep
+        sigma_start: float = scaled.sigmas(1).item()
         remapped["sigma_start"] = math.sqrt(sigma_start)
 
     if not schedule_modifier:

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -20,6 +20,7 @@ from skrample.pytorch.noise import (
 )
 from skrample.sampling import PREDICTOR, SkrampleSampler, SKSamples, StochasticSampler
 from skrample.scheduling import ScheduleModifier, SkrampleSchedule
+from skrample.common import MergeStrategy
 
 if TYPE_CHECKING:
     from diffusers.configuration_utils import ConfigMixin
@@ -80,31 +81,6 @@ DEFAULT_FAKE_CONFIG = {  # Required for FluxPipeline to not die
     "max_shift": 1.15,
     "use_dynamic_shifting": True,
 }
-
-
-@enum.unique
-class MergeStrategy(enum.StrEnum):  # str for easy UI options
-    Ours = enum.auto()
-    Theirs = enum.auto()
-    After = enum.auto()
-    Before = enum.auto()
-    UniqueAfter = enum.auto()
-    UniqueBefore = enum.auto()
-
-    def merge[T](self, ours: list[T], theirs: list[T], cmp: Callable[[T, T], bool] = lambda a, b: a == b) -> list[T]:
-        match self:
-            case MergeStrategy.Ours:
-                return ours
-            case MergeStrategy.Theirs:
-                return theirs
-            case MergeStrategy.After:
-                return ours + theirs
-            case MergeStrategy.Before:
-                return theirs + ours
-            case MergeStrategy.UniqueAfter:
-                return ours + [i for i in theirs if not any(map(cmp, ours, [i] * len(theirs)))]
-            case MergeStrategy.UniqueBefore:
-                return theirs + [i for i in ours if not any(map(cmp, theirs, [i] * len(ours)))]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -1,8 +1,7 @@
 import dataclasses
-import enum
 import math
 from collections import OrderedDict
-from collections.abc import Callable, Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -11,6 +10,7 @@ from numpy.typing import NDArray
 from torch import Tensor
 
 from skrample import sampling, scheduling
+from skrample.common import MergeStrategy
 from skrample.pytorch.noise import (
     BatchTensorNoise,
     Random,
@@ -20,7 +20,6 @@ from skrample.pytorch.noise import (
 )
 from skrample.sampling import PREDICTOR, SkrampleSampler, SKSamples, StochasticSampler
 from skrample.scheduling import ScheduleModifier, SkrampleSchedule
-from skrample.common import MergeStrategy
 
 if TYPE_CHECKING:
     from diffusers.configuration_utils import ConfigMixin

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
+from skrample.common import safe_log
+
 if TYPE_CHECKING:
     from torch.types import Tensor
 
@@ -17,13 +19,6 @@ else:
 
 
 PREDICTOR = Callable[[Sample, Sample, float, bool], Sample]
-
-
-def safe_log(x: float) -> float:
-    try:
-        return math.log(x)
-    except ValueError:
-        return math.inf
 
 
 def sigma_normal(sigma: float, subnormal: bool = False) -> tuple[float, float]:

--- a/skrample/scheduling.py
+++ b/skrample/scheduling.py
@@ -196,46 +196,6 @@ class SigmoidCDF(Linear):
 
 
 @dataclass
-class Flow(Linear):
-    mu: float | None = None
-    shift: float = 3.0
-    # base_image_seq_len: int = 256
-    # max_image_seq_len: float = 4096
-    # base_shift: float = 0.5
-    # max_shift: float = 1.15
-    # use_dynamic_shifting: bool = True
-
-    def sigmas(self, steps: int) -> NDArray[np.float64]:
-        # # # The actual schedule code
-        #
-        # # Strange it's 1000 -> 1 instead of 999 -> 0?
-        # sigma_start, sigma_end = 1, 1 / self.num_train_timesteps
-        #
-        # if self.mu is None:
-        #     sigma_start = self.shift * sigma_start / (1 + (self.shift - 1) * sigma_start)
-        #     sigma_end = self.shift * sigma_end / (1 + (self.shift - 1) * sigma_end)
-        #
-        # sigmas = np.linspace(sigma_start, sigma_end, steps + 1, dtype=np.float64)[:-1]
-
-        # What the flux pipeline overrides it to. Seems more correct?
-        sigmas = super().sigmas(steps)
-
-        # Compute flow match in 0-1 scale
-        # TODO(beinsezii): maybe the shift itself should be rewritten to accomodate start/end?
-        start, end = sigmas.max(), 0
-        sigmas = normalize(sigmas, start=start, end=end)
-
-        if self.mu is not None:  # dynamic
-            sigmas = math.exp(self.mu) / (math.exp(self.mu) + (1 / sigmas - 1))
-        else:  # non-dynamic
-            sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)
-
-        sigmas = regularize(sigmas, start=start, end=end)
-
-        return sigmas  # type: ignore
-
-
-@dataclass
 class ScheduleModifier(SkrampleSchedule):
     base: SkrampleSchedule
 

--- a/skrample/scheduling.py
+++ b/skrample/scheduling.py
@@ -182,7 +182,8 @@ class SigmoidCDF(Linear):
 
         step_peak = 1 / (steps * math.pi / 2)
         probabilities = np.linspace(step_peak, 1 - step_peak, steps, dtype=np.float64)
-        return sigmoid(norm.ppf(probabilities) * self.cdf_scale)
+        sigmas = sigmoid(norm.ppf(probabilities) * self.cdf_scale)
+        return regularize(sigmas, start=self.sigma_start)
 
 
 @dataclass

--- a/skrample/scheduling.py
+++ b/skrample/scheduling.py
@@ -5,17 +5,7 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
-
-def normalize(regular_array: NDArray[np.float64], start: float = 1, end: float = 0) -> NDArray[np.float64]:
-    return (regular_array - end) / (start - end)
-
-
-def regularize(normal_array: NDArray[np.float64], start: float = 1, end: float = 0) -> NDArray[np.float64]:
-    return normal_array * (start - end) + end
-
-
-def sigmoid(array: NDArray[np.float64]) -> NDArray[np.float64]:
-    return 1 / (1 + np.exp(array))
+from skrample.common import normalize, regularize, sigmoid
 
 
 @dataclass

--- a/skrample/scheduling.py
+++ b/skrample/scheduling.py
@@ -205,7 +205,7 @@ class ScheduleModifier(SkrampleSchedule):
 
     @property
     def all(self) -> list[SkrampleSchedule]:
-        bases: list[SkrampleSchedule] = []
+        bases: list[SkrampleSchedule] = [self]
         last = self.base
         while isinstance(last, ScheduleModifier):
             bases.append(last)

--- a/tests/diffusers_map.py
+++ b/tests/diffusers_map.py
@@ -12,7 +12,7 @@ from testing_common import FLOW_CONFIG, SCALED_CONFIG
 
 from skrample.diffusers import SkrampleWrapperScheduler
 from skrample.sampling import DPM, EPSILON, FLOW, IPNDM, VELOCITY, Euler, UniPC
-from skrample.scheduling import Beta, Exponential, Flow, Karras, Scaled
+from skrample.scheduling import Beta, Exponential, FlowShift, Karras, Linear, Scaled
 
 
 def check_wrapper(wrapper: SkrampleWrapperScheduler, scheduler: ConfigMixin, params: list[str] = []) -> None:
@@ -57,7 +57,7 @@ def test_dpm() -> None:
                         )
 
     check_wrapper(
-        SkrampleWrapperScheduler(DPM(predictor=FLOW, order=2), Flow()),
+        SkrampleWrapperScheduler(DPM(predictor=FLOW, order=2), FlowShift(Linear())),
         DPMSolverMultistepScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
     )
 
@@ -72,8 +72,12 @@ def test_euler() -> None:
         EulerAncestralDiscreteScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
     )
     check_wrapper(
-        SkrampleWrapperScheduler(Euler(predictor=FLOW), Flow()),
+        SkrampleWrapperScheduler(Euler(predictor=FLOW), FlowShift(Linear())),
         FlowMatchEulerDiscreteScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
+    )
+    check_wrapper(
+        SkrampleWrapperScheduler(Euler(predictor=FLOW), Beta(FlowShift(Linear()))),
+        FlowMatchEulerDiscreteScheduler.from_config(FLOW_CONFIG | {"use_beta_sigmas": True}),  # type: ignore ConfigMixin
     )
 
 
@@ -90,7 +94,7 @@ def test_unipc() -> None:
         UniPCMultistepScheduler.from_config(SCALED_CONFIG),  # type: ignore ConfigMixin
     )
     check_wrapper(
-        SkrampleWrapperScheduler(UniPC(predictor=FLOW, order=2), Flow()),
+        SkrampleWrapperScheduler(UniPC(predictor=FLOW, order=2), FlowShift(Linear())),
         UniPCMultistepScheduler.from_config(FLOW_CONFIG),  # type: ignore ConfigMixin
     )
 

--- a/tests/diffusers_pipes.py
+++ b/tests/diffusers_pipes.py
@@ -12,8 +12,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchE
 from testing_common import compare_tensors
 
 from skrample.diffusers import SkrampleWrapperScheduler
-from skrample.sampling import FLOW, Euler
-from skrample.scheduling import Flow, Scaled
 
 pytestmark = pytest.mark.skip("Slow")
 
@@ -75,13 +73,12 @@ def test_sdxl_i2i() -> None:
     pipe.enable_model_cpu_offload(device=dv)
     assert isinstance(pipe, StableDiffusionXLImg2ImgPipeline)
 
-    a = SkrampleWrapperScheduler(Euler(), Scaled(uniform=False))
     b = EulerDiscreteScheduler.from_config(pipe.scheduler.config)
     assert isinstance(b, EulerDiscreteScheduler)
 
     compare_schedulers(
         pipe,
-        a,
+        SkrampleWrapperScheduler.from_diffusers_config(b),
         b,
         image=torch.zeros([1, 4, 32, 32], dtype=dt, device=dv),
         num_inference_steps=8,
@@ -99,7 +96,6 @@ def test_flux_i2i() -> None:
     pipe.enable_model_cpu_offload(device=dv)
     assert isinstance(pipe, FluxImg2ImgPipeline)
 
-    a = SkrampleWrapperScheduler(Euler(predictor=FLOW), Flow(shift=3))
     b = FlowMatchEulerDiscreteScheduler.from_config(pipe.scheduler.config)
     assert isinstance(b, FlowMatchEulerDiscreteScheduler)
 
@@ -110,7 +106,7 @@ def test_flux_i2i() -> None:
 
     compare_schedulers(
         pipe,
-        a,
+        SkrampleWrapperScheduler.from_diffusers_config(b),
         b,
         5e-3,  # close enough for now
         height=256,

--- a/tests/diffusers_schedules.py
+++ b/tests/diffusers_schedules.py
@@ -3,7 +3,7 @@ from diffusers.schedulers.scheduling_euler_discrete import EulerDiscreteSchedule
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
 from testing_common import FLOW_CONFIG, SCALED_CONFIG, compare_tensors
 
-from skrample.scheduling import ZSNR, Beta, Exponential, Flow, Karras, Scaled, SkrampleSchedule
+from skrample.scheduling import ZSNR, Beta, Exponential, FlowShift, Karras, Linear, Scaled, SkrampleSchedule
 
 
 def compare_schedules(
@@ -98,7 +98,7 @@ def test_zsnr() -> None:
 
 def test_flow_dynamic() -> None:
     compare_schedules(
-        Flow(mu=0.7),
+        FlowShift(Linear(), mu=0.7),
         FlowMatchEulerDiscreteScheduler.from_config(  # type: ignore  # Diffusers return BS
             FLOW_CONFIG,
         ),
@@ -108,7 +108,7 @@ def test_flow_dynamic() -> None:
 
 def test_flow() -> None:
     compare_schedules(
-        Flow(),
+        FlowShift(Linear()),
         FlowMatchEulerDiscreteScheduler.from_config(  # type: ignore  # Diffusers return BS
             FLOW_CONFIG | {"use_dynamic_shifting": False}
         ),
@@ -118,7 +118,7 @@ def test_flow() -> None:
 
 def test_flow_beta() -> None:
     compare_schedules(
-        Beta(Flow()),
+        Beta(FlowShift(Linear())),
         FlowMatchEulerDiscreteScheduler.from_config(  # type: ignore  # Diffusers return BS
             FLOW_CONFIG | {"use_dynamic_shifting": False},
             use_beta_sigmas=True,
@@ -128,7 +128,7 @@ def test_flow_beta() -> None:
 
 def test_flow_exponential() -> None:
     compare_schedules(
-        Exponential(Flow()),
+        Exponential(FlowShift(Linear())),
         FlowMatchEulerDiscreteScheduler.from_config(  # type: ignore  # Diffusers return BS
             FLOW_CONFIG | {"use_dynamic_shifting": False},
             use_exponential_sigmas=True,
@@ -138,7 +138,7 @@ def test_flow_exponential() -> None:
 
 def test_flow_karras() -> None:
     compare_schedules(
-        Karras(Flow()),
+        Karras(FlowShift(Linear())),
         FlowMatchEulerDiscreteScheduler.from_config(  # type: ignore  # Diffusers return BS
             FLOW_CONFIG | {"use_dynamic_shifting": False},
             use_karras_sigmas=True,

--- a/tests/miscellaneous.py
+++ b/tests/miscellaneous.py
@@ -5,11 +5,11 @@ import torch
 from testing_common import compare_tensors
 
 from skrample.sampling import DPM, IPNDM, Euler, SKSamples, UniPC
-from skrample.scheduling import Flow, Scaled
+from skrample.scheduling import FlowShift, Linear, Scaled
 
 
 def test_sigmas_to_timesteps() -> None:
-    for schedule in [Scaled(), Scaled(beta_scale=1), Flow()]:  # base schedules
+    for schedule in [Scaled(), Scaled(beta_scale=1), FlowShift(Linear())]:  # base schedules
         timesteps = schedule.timesteps(123)
         timesteps_inv = schedule.sigmas_to_timesteps(schedule.sigmas(123))
         compare_tensors(torch.tensor(timesteps), torch.tensor(timesteps_inv), margin=0)  # shocked this rounds good
@@ -18,7 +18,7 @@ def test_sigmas_to_timesteps() -> None:
 def test_sampler_generics() -> None:
     eps = 1e-12
     for sampler in Euler(), DPM(order=2), IPNDM(), UniPC(order=3):
-        for schedule in Scaled(), Flow():
+        for schedule in Scaled(), FlowShift(Linear()):
             i, o = random.random(), random.random()
             prev = [SKSamples(random.random(), random.random(), random.random()) for _ in range(9)]
 


### PR DESCRIPTION
Began as a simple nerd snipe for the training flux schedule using `np.sort(np.randn(count))` instead of a pure linspace. Thought "oh I can just make that a nice dist function as a schedule for inference" but that also meant having Flow() and SigFlow() or something to that effect which bothered me on a fundamental level so I had to rewrite it all.

Friendship ended with Flow(ScheduleCommon), now FlowShift(ScheduleModifier) is my new best friend