### PR TITLE
Use two pytest workers for CI

### DIFF
--- a/.github/workflows/master_ci.yml
+++ b/.github/workflows/master_ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pytest
         if: '!cancelled()'
-        run: uv run --no-sync pytest
+        run: uv run --no-sync pytest -n 2
 
   high:
     runs-on: ubuntu-latest
@@ -67,4 +67,4 @@ jobs:
 
       - name: Pytest
         if: '!cancelled()'
-        run: uv run --no-sync pytest
+        run: uv run --no-sync pytest -n 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ test = [
     "diffusers>=0.32",
     "protobuf>=5.29",
     "pyright>=1.1.397",
+    "pytest-xdist>=3.6.1",
     "pytest>=8.3",
     "ruff>=0.11",
     "sentencepiece>=0.2",


### PR DESCRIPTION
Only two as majority of the work is already threaded. Simply helps fill gaps; about 35% faster locally