### PR TITLE
Add SPC sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ ScheduleModifier has multiple new helper functions for working with frozen
 scheduling.schedule_lru() for cached schedule retrieval.
 Overhead of SkrampleWrapperSchedule.step() is reduced by 95% when using a highly complex schedule class
 
+SPC sampler - simple predictor/corrector using midpoints
+
 ## 0.2.3
 ### Fixes
 Wrapper seed generation failing on non-contiguous inputs

--- a/scripts/plot_skrample.py
+++ b/scripts/plot_skrample.py
@@ -66,6 +66,7 @@ SAMPLERS: dict[str, sampling.SkrampleSampler] = {
     "adams": sampling.Adams(),
     "dpm": sampling.DPM(),
     "unipc": sampling.UniPC(),
+    "spc": sampling.SPC(),
 }
 for k, v in list(SAMPLERS.items()):
     if isinstance(v, sampling.HighOrderSampler):

--- a/scripts/plot_skrample.py
+++ b/scripts/plot_skrample.py
@@ -107,7 +107,7 @@ parser_sampler.add_argument(
     type=str,
     nargs="+",
     choices=list(SAMPLERS.keys()),
-    default=["euler", "adams", "dpm2", "unipc"],
+    default=["euler", "adams", "dpm2", "unipc", "spc"],
 )
 
 # Schedules

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -26,10 +26,13 @@ class SKSamples[T: Sample]:
     "Final result. What you probably want"
 
     prediction: T
-    "Just the prediction from SkrampleSampler.predictor if it's used"
+    "The model prediction"
 
     sample: T
-    "The unmodified model input"
+    "The model input"
+
+    noise: T | None = None
+    "The extra stochastic noise"
 
 
 @dataclass(frozen=True)
@@ -39,6 +42,16 @@ class SkrampleSampler(ABC):
 
     Unless otherwise specified, the Sample type is a stand-in that is
     type checked against torch.Tensor but should be generic enough to use with ndarrays or even raw floats"""
+
+    @property
+    def require_noise(self) -> bool:
+        "Whether or not the sampler requires `noise: T` be passed"
+        return False
+
+    @property
+    def require_previous(self) -> int:
+        "How many prior samples the sampler needs in `previous: list[T]`"
+        return 0
 
     @staticmethod
     def get_sigma(step: int, sigma_schedule: NDArray) -> float:
@@ -109,6 +122,10 @@ class HighOrderSampler(SkrampleSampler):
     def max_order(self) -> int:
         pass
 
+    @property
+    def require_previous(self) -> int:
+        return max(min(self.order, self.max_order), self.min_order) - 1
+
     def effective_order(self, step: int, schedule: NDArray, previous: list[SKSamples]) -> int:
         "The order used in calculation given a step, schedule length, and previous sample count"
         return max(
@@ -127,6 +144,10 @@ class HighOrderSampler(SkrampleSampler):
 class StochasticSampler(SkrampleSampler):
     add_noise: bool = False
     "Flag for whether or not to add the given noise"
+
+    @property
+    def require_noise(self) -> bool:
+        return self.add_noise
 
 
 @dataclass(frozen=True)
@@ -303,6 +324,14 @@ class UniPC(HighOrderSampler):
         # 4-6 is mostly stable now, 7-9 depends on the model. What ranges are actually useful..?
         return 9
 
+    @property
+    def require_noise(self) -> bool:
+        return self.solver.require_noise if self.solver else False
+
+    @property
+    def require_previous(self) -> int:
+        return max(super().require_previous, self.solver.require_previous if self.solver else 0)
+
     def _uni_p_c_prelude[T: Sample](
         self,
         prediction: T,
@@ -459,6 +488,14 @@ class SPC(HighOrderSampler):
     def min_order(self) -> int:
         return 2
 
+    @property
+    def require_noise(self) -> bool:
+        return self.predictor.require_noise or self.corrector.require_noise
+
+    @property
+    def require_previous(self) -> int:
+        return max(super().require_previous, self.predictor.require_previous, self.corrector.require_previous)
+
     def sample[T: Sample](
         self,
         sample: T,
@@ -482,10 +519,13 @@ class SPC(HighOrderSampler):
                         step - 1,
                         sigma_schedule,
                         sigma_transform,
-                        noise,
+                        prior.noise,
                         offset_previous,
                     ).final
                 )
                 * self.midpoint
             )  # type: ignore
-        return self.predictor.sample(sample, prediction, step, sigma_schedule, sigma_transform, noise, previous)
+        return replace(
+            self.predictor.sample(sample, prediction, step, sigma_schedule, sigma_transform, noise, previous),
+            noise=noise,  # the corrector may or may not need noise so we always store
+        )

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -471,13 +471,19 @@ class SPC(HighOrderSampler):
     ) -> SKSamples[T]:
         if previous:
             predictions = [*(p.prediction for p in previous), prediction]
-            previous = [replace(p, prediction=pred) for p, pred in zip(previous, predictions[1:], strict=True)]
-            prior = previous.pop()
+            offset_previous = [replace(p, prediction=pred) for p, pred in zip(previous, predictions[1:], strict=True)]
+            prior = offset_previous.pop()
             sample = (
                 sample * (1 - self.midpoint)
                 + (
                     self.corrector.sample(
-                        prior.sample, prior.prediction, step - 1, sigma_schedule, sigma_transform, noise, previous
+                        prior.sample,
+                        prior.prediction,
+                        step - 1,
+                        sigma_schedule,
+                        sigma_transform,
+                        noise,
+                        offset_previous,
                     ).final
                 )
                 * self.midpoint

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -447,6 +447,7 @@ class SPC(HighOrderSampler):
 
     predictor: SkrampleSampler = DPM(order=3)  # noqa: RUF009  # Is immutable
     corrector: SkrampleSampler = DPM(order=1)  # noqa: RUF009  # Is immutable
+    midpoint: float = 0.5
 
     order: int = 2
 
@@ -473,11 +474,12 @@ class SPC(HighOrderSampler):
             previous = [replace(p, prediction=pred) for p, pred in zip(previous, predictions[1:], strict=True)]
             prior = previous.pop()
             sample = (
-                sample
+                sample * (1 - self.midpoint)
                 + (
                     self.corrector.sample(
                         prior.sample, prior.prediction, step - 1, sigma_schedule, sigma_transform, noise, previous
                     ).final
                 )
-            ) / 2  # type: ignore
+                * self.midpoint
+            )  # type: ignore
         return self.predictor.sample(sample, prediction, step, sigma_schedule, sigma_transform, noise, previous)

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -494,7 +494,7 @@ class SPC(HighOrderSampler):
 
     @property
     def require_previous(self) -> int:
-        return max(super().require_previous, self.predictor.require_previous, self.corrector.require_previous)
+        return max(self.predictor.require_previous, self.corrector.require_previous + 1)
 
     def sample[T: Sample](
         self,

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -469,11 +469,14 @@ class SPC(HighOrderSampler):
         previous: list[SKSamples[T]] = [],
     ) -> SKSamples[T]:
         if previous:
+            predictions = [*(p.prediction for p in previous), prediction]
+            previous = [replace(p, prediction=pred) for p, pred in zip(previous, predictions[1:], strict=True)]
+            prior = previous.pop()
             sample = (
                 sample
                 + (
                     self.corrector.sample(
-                        previous[-1].sample, prediction, step - 1, sigma_schedule, sigma_transform, noise, previous[:-1]
+                        prior.sample, prior.prediction, step - 1, sigma_schedule, sigma_transform, noise, previous
                     ).final
                 )
             ) / 2  # type: ignore

--- a/skrample/sampling.py
+++ b/skrample/sampling.py
@@ -330,7 +330,8 @@ class UniPC(HighOrderSampler):
 
     @property
     def require_previous(self) -> int:
-        return max(super().require_previous, self.solver.require_previous if self.solver else 0)
+        # +1 for correction
+        return max(super().require_previous + 1, self.solver.require_previous if self.solver else 0)
 
     def _uni_p_c_prelude[T: Sample](
         self,

--- a/tests/miscellaneous.py
+++ b/tests/miscellaneous.py
@@ -1,16 +1,48 @@
 import random
+from dataclasses import replace
 
 import numpy as np
 import torch
 from testing_common import compare_tensors
 
+from skrample.common import sigma_complement
 from skrample.diffusers import SkrampleWrapperScheduler
-from skrample.sampling import DPM, Adams, Euler, SKSamples, UniPC
-from skrample.scheduling import Beta, FlowShift, Karras, Linear, Scaled
+from skrample.sampling import (
+    DPM,
+    SPC,
+    Adams,
+    Euler,
+    HighOrderSampler,
+    SkrampleSampler,
+    SKSamples,
+    StochasticSampler,
+    UniPC,
+)
+from skrample.scheduling import Beta, FlowShift, Karras, Linear, Scaled, SigmoidCDF
+
+ALL_SAMPLERS = [
+    Adams,
+    DPM,
+    Euler,
+    SPC,
+    UniPC,
+]
+
+ALL_SCHEDULES = [
+    Linear,
+    Scaled,
+    SigmoidCDF,
+]
+
+ALL_MODIFIERS = [
+    Beta,
+    FlowShift,
+    Karras,
+]
 
 
 def test_sigmas_to_timesteps() -> None:
-    for schedule in [Scaled(), Scaled(beta_scale=1), FlowShift(Linear())]:  # base schedules
+    for schedule in [*(cls() for cls in ALL_SCHEDULES), Scaled(beta_scale=1)]:  # base schedules
         timesteps = schedule.timesteps(123)
         timesteps_inv = schedule.sigmas_to_timesteps(schedule.sigmas(123))
         compare_tensors(torch.tensor(timesteps), torch.tensor(timesteps_inv), margin=0)  # shocked this rounds good
@@ -18,7 +50,10 @@ def test_sigmas_to_timesteps() -> None:
 
 def test_sampler_generics() -> None:
     eps = 1e-12
-    for sampler in Euler(), DPM(order=2), Adams(), UniPC(order=3):
+    for sampler in [
+        *(cls() for cls in ALL_SAMPLERS),
+        *(cls(order=cls().max_order) for cls in ALL_SAMPLERS if issubclass(cls, HighOrderSampler)),
+    ]:
         for schedule in Scaled(), FlowShift(Linear()):
             i, o = random.random(), random.random()
             prev = [SKSamples(random.random(), random.random(), random.random()) for _ in range(9)]
@@ -55,3 +90,87 @@ def test_mu_set() -> None:
     b = SkrampleWrapperScheduler(DPM(), Beta(FlowShift(Karras(Linear()), mu=mu)))
     a.set_timesteps(1, mu=mu)
     assert a.schedule == b.schedule
+
+
+def test_require_previous() -> None:
+    samplers: list[SkrampleSampler] = []
+    for cls in ALL_SAMPLERS:
+        if issubclass(cls, HighOrderSampler):
+            samplers.extend([cls(order=o + 1) for o in range(cls().min_order, cls().max_order)])
+        else:
+            samplers.append(cls())
+
+    for o1 in range(1, 4):
+        for o2 in range(1, 4):
+            samplers.append(UniPC(order=o1, solver=Adams(order=o2)))
+            samplers.append(SPC(predictor=Adams(order=o1), corrector=Adams(order=o2)))
+
+    for sampler in samplers:
+        sample = 1.5
+        prediction = 0.5
+        previous = [SKSamples(n / 2, n * 2, n * 1.5) for n in range(100)]
+
+        a = sampler.sample(
+            sample,
+            prediction,
+            31,
+            Linear().sigmas(100),
+            sigma_complement,
+            None,
+            previous,
+        )
+        b = sampler.sample(
+            sample,
+            prediction,
+            31,
+            Linear().sigmas(100),
+            sigma_complement,
+            None,
+            previous[len(previous) - sampler.require_previous :],
+        )
+
+        assert a == b, (sampler, sampler.require_previous)
+
+
+def test_require_noise() -> None:
+    samplers: list[SkrampleSampler] = []
+    for cls in ALL_SAMPLERS:
+        if issubclass(cls, StochasticSampler):
+            samplers.extend([cls(add_noise=n) for n in (False, True)])
+        else:
+            samplers.append(cls())
+
+    for n1 in (False, True):
+        for n2 in (False, True):
+            samplers.append(UniPC(solver=DPM(add_noise=n2)))
+            samplers.append(SPC(predictor=DPM(add_noise=n1), corrector=DPM(add_noise=n2)))
+
+    for sampler in samplers:
+        sample = 1.5
+        prediction = 0.5
+        previous = [SKSamples(n / 2, n * 2, n * 1.5) for n in range(100)]
+        noise = -0.5
+
+        a = sampler.sample(
+            sample,
+            prediction,
+            31,
+            Linear().sigmas(100),
+            sigma_complement,
+            noise,
+            previous,
+        )
+        b = sampler.sample(
+            sample,
+            prediction,
+            31,
+            Linear().sigmas(100),
+            sigma_complement,
+            noise if sampler.require_noise else None,
+            previous,
+        )
+
+        # Don't compare stored noise since it's expected diff
+        b = replace(b, noise=a.noise)
+
+        assert a == b, (sampler, sampler.require_noise)


### PR DESCRIPTION
Just uses one sampler to predict, another to correct the prior via midpoint. Almost certainly has been invented before but since I haven't googled this pattern yet I'm just going to pretend it's mine and give it my own name.

Started because I was curious about an inverse Heun that does Euler(x-1) + Euler(x0) so it would be multistep compatible. While that worked, it's basically just a worse Adams-Bashforth since the 2nd order coefficients are also just midpoint against previous.

So I tried expanding to DPM, tried monkeying with recursion for adaptive corrections (don't do this), and eventually just settled on any P/C combo with `P=DPM(order=3) C=DPM(order=1)` defaults cause it just happens to look nice in SDXL and on the plot.

may or may not break with stochastic solvers but I don't feel like modifying SKSamples again tonight just to add noise retention to high order stochastic classes.

higher order correction is funky right now because the samples and predictions are misaligned. I think before merge I might try some generator to re-zip the entire history on-the-fly to accommodate this.