### PR TITLE
Better RNG Groundwork + Brownian Optimization

### DIFF
--- a/examples/functional.py
+++ b/examples/functional.py
@@ -66,7 +66,7 @@ with torch.inference_mode():
         model_transform=models.NoiseModel(),
         schedule=schedule,
         steps=steps,
-        rng=lambda: rng.generate().to(dtype=dtype, device=device),
+        rng=lambda step: rng.generate(step).to(dtype=dtype, device=device),
         callback=lambda x, n, d: bar.update(n + 1 - bar.n),
     )
 

--- a/scripts/brownian.py
+++ b/scripts/brownian.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+
+from time import perf_counter_ns
+
+import torch
+
+from skrample.common import Step
+from skrample.pytorch.noise import Brownian
+
+print("device\tdtype\tshape\tsteps\tmedian_ms")
+with torch.inference_mode():
+    for device in torch.device("cuda:0"), torch.device("cpu"):
+        for dtype in torch.bfloat16, torch.float32:
+            if dtype == torch.bfloat16 and device.type == "cpu":
+                continue
+            for shape in (1, 4, 512 // 8, 512 // 8), (2, 16, 1280 // 8, 720 // 8):
+                for steps in 10, 50, 200:
+                    rng = Brownian.from_inputs(shape, torch.Generator(device).manual_seed(42), dtype=dtype)
+
+                    clocks: list[int] = []
+
+                    for n in range(steps):
+                        step = Step.from_int(n, steps)
+                        t = perf_counter_ns()
+                        _ = rng.generate(step)
+                        clocks.append(perf_counter_ns() - t)
+
+                    print(f"{device}\t{dtype}\t{shape}\t{steps}\t{sorted(clocks)[len(clocks) // 2] / 1e6:.2f}")

--- a/scripts/plot_skrample.py
+++ b/scripts/plot_skrample.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 
 import math
+import random
 from argparse import ArgumentParser, BooleanOptionalAction
 from collections.abc import Generator
 from dataclasses import replace
 from pathlib import Path
-from random import random
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -210,7 +210,7 @@ if args.command == "samplers":
             model_transform=SPACES[args.transform][2],
             schedule=schedule,
             steps=adjusted,
-            rng=random,
+            rng=lambda _: random.random(),
             callback=callback,
         )
 

--- a/scripts/sampling_self_measure.py
+++ b/scripts/sampling_self_measure.py
@@ -44,7 +44,7 @@ def capture(
         lambda x, t, s, a: x - math.sin(t),
         model,
         scheduling.Hyper(schedule),
-        random.random,
+        lambda _: random.random(),
         MEASURED_STEPS,
         callback=lambda x, i, d: samples.append(x),
     )

--- a/skrample/common.py
+++ b/skrample/common.py
@@ -17,7 +17,7 @@ else:
     type Sample = float | NDArray[np.floating]
 
 
-type RNG[T: Sample] = Callable[[], T]
+type RNG[T: Sample] = Callable[[Step | None], T]
 "Distribution should match model, typically normal"
 
 

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -16,13 +16,7 @@ from torch import Tensor
 import skrample.sampling.structured as sampling
 from skrample import scheduling
 from skrample.common import DeltaPoint, MergeStrategy, Point, Sample, Step
-from skrample.pytorch.noise import (
-    BatchTensorNoise,
-    Random,
-    TensorNoiseCommon,
-    TensorNoiseProps,
-    schedule_to_ramp,
-)
+from skrample.pytorch.noise import BatchTensorNoise, Random, TensorNoiseCommon, TensorNoiseProps
 from skrample.sampling import functional, interface, models, tableaux, traits
 from skrample.sampling.models import DataModel, DiffusionModel, FlowModel, NoiseModel, VelocityModel
 from skrample.sampling.structured import SampleInput, SKSamples, StructuredSampler
@@ -296,7 +290,7 @@ class SkrampleWrapperCore(abc.ABC):
 
     def get_step_noise[T: TensorNoiseProps | None](
         self,
-        step: int,
+        step: Step,
         sample: torch.Tensor,
         noise_type: type[TensorNoiseCommon[T]],
         noise_props: T | None,
@@ -313,7 +307,9 @@ class SkrampleWrapperCore(abc.ABC):
                 # multiply by step index to spread the values and minimize clash
                 # does not work across batch sizes but at least Flux will have something mostly deterministic
                 seeds = [
-                    torch.Generator().manual_seed(int(b.reshape(b.numel())[b.numel() // 2].item() * 1e4) * (step + 1))
+                    torch.Generator().manual_seed(
+                        int(b.reshape(b.numel())[b.numel() // 2].item() * 1e4 * (step.position() + 1))
+                    )
                     for b in sample
                 ]
 
@@ -322,11 +318,10 @@ class SkrampleWrapperCore(abc.ABC):
                 unit_shape=sample.shape[1:],
                 seeds=seeds,  # ty: ignore # no clue
                 props=noise_props,
-                ramp=schedule_to_ramp(self.schedule_np[:: self.order])[self._index // self.order :],
                 dtype=torch.float32,
             )
 
-        return self._noise_generator.generate().to(dtype=dtype or sample.dtype, device=sample.device)
+        return self._noise_generator.generate(step).to(dtype=dtype or sample.dtype, device=sample.device)
 
     @abc.abstractmethod
     def scale_noise(self, sample: Tensor, timestep: Tensor, noise: Tensor) -> Tensor: ...
@@ -529,6 +524,7 @@ class SkrampleWrapperScheduler[T: TensorNoiseProps | None](SkrampleWrapperCore):
     ) -> tuple[Tensor, Tensor] | OrderedDict[str, Tensor]:
         schedule = self.schedule_np
         step = schedule[:, 0].tolist().index(timestep if isinstance(timestep, int | float) else timestep.item())
+        step = Step.from_int(step, len(schedule))
 
         if self.sampler.require_noise:
             noise = self.get_step_noise(step, sample, self.noise_type, self.noise_props, generator, self.compute_scale)
@@ -541,7 +537,7 @@ class SkrampleWrapperScheduler[T: TensorNoiseProps | None](SkrampleWrapperCore):
             packed=SampleInput(
                 sample=sample_cast,
                 prediction=model_output.to(dtype=self.compute_scale),
-                step=Step.from_int(step, len(schedule)),
+                step=step,
                 noise=noise,
             ),
             model_transform=self.model,
@@ -586,7 +582,6 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
         self._index: int = 0
         self._derivatives: list[Tensor] = []
         self._sample: Tensor | None = None
-        self._noise: Tensor | None = None
         self._schedule = self.schedule  # copy of original for restoration in set_timesteps
 
     @abc.abstractmethod
@@ -692,6 +687,7 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
         S0: Point,
         S1: Point,
         SN: Point,
+        generator: torch.Generator | list[torch.Generator] | None,
     ) -> Tensor:
         nodes, weights = self.tableau()
 
@@ -701,17 +697,27 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
         sample = self._sample
 
         if len(self._derivatives) == len(weights):
+            if abs(self.stochasticity) > 1e-8:
+                noise = self.get_step_noise(
+                    Step.from_int(self._index // self.order, self._steps),
+                    sample,
+                    self.noise_type,
+                    self.noise_props,
+                    generator,
+                    self.compute_scale,
+                )
+            else:
+                noise = None
             final: Tensor = model_transform.forward(  # ty: ignore # output is a tensor
                 sample,
                 math.sumprod(self._derivatives, weights),  # type: ignore # it's a tensor
                 DeltaPoint(S0, S1),
-                self._noise,
+                noise,
                 self.stochasticity,
             )
 
             self._derivatives.clear()
             self._sample = None
-            self._noise = None
 
             return final
 
@@ -739,16 +745,6 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
     ) -> tuple[Tensor, Tensor] | OrderedDict[str, Tensor]:
         assert timestep == self.all_points[self._index].timestep
 
-        if self._noise is None and abs(self.stochasticity) > 1e-8:
-            self._noise = self.get_step_noise(
-                self._index,
-                sample,
-                self.noise_type,
-                self.noise_props,
-                generator,
-                self.compute_scale,
-            )
-
         points = [*self.all_points, Point(0, 0, 1)]
 
         if self.derivative_transform:
@@ -771,6 +767,7 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
             S0=points[S0_idx],
             S1=points[S1_idx],
             SN=points[SN_idx],
+            generator=generator,
         )
 
         self._index += 1
@@ -789,6 +786,7 @@ class RKWrapperCore[T: TensorNoiseProps | None, U: functional.FunctionalUnified]
                 S0=points[S0_idx],
                 S1=points[S1_idx],
                 SN=points[SN_idx + 1],
+                generator=generator,
             )
 
             self._index += 1

--- a/skrample/diffusers.py
+++ b/skrample/diffusers.py
@@ -318,7 +318,8 @@ class SkrampleWrapperCore(abc.ABC):
                 unit_shape=sample.shape[1:],
                 seeds=seeds,  # ty: ignore # no clue
                 props=noise_props,
-                dtype=torch.float32,
+                # Anything except float32 performs terribly on cpu, otherwise native model precision is best
+                dtype=torch.float32 if any(s.device.type == "cpu" for s in seeds) else sample.dtype,
             )
 
         return self._noise_generator.generate(step).to(dtype=dtype or sample.dtype, device=sample.device)

--- a/skrample/pytorch/noise.py
+++ b/skrample/pytorch/noise.py
@@ -17,7 +17,7 @@ class TensorNoiseProps:
 @dataclass
 class SkrampleTensorNoise(ABC):
     @abstractmethod
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
         """Next noise tensor in the sequence.
         May raise an exception if at the end of sequence.
         Should be assumed to be stateful, and not used for multiple jobs"""
@@ -70,7 +70,7 @@ class Random(TensorNoiseCommon[None]):
     ) -> Self:
         return cls(shape, seed, dtype, props)
 
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
         return self._randn()
 
 
@@ -105,7 +105,7 @@ class Offset(TensorNoiseCommon[OffsetProps]):
         shape = tuple([d if n in self.props.dims else 1 for n, d in enumerate(self.shape)])
         return self._randn(shape) * self.props.strength**2
 
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
         if self.props.static and self.static_offset is not None:
             offset = self.static_offset
         else:
@@ -199,7 +199,7 @@ class Pyramid(TensorNoiseCommon[PyramidProps]):
         skip = min(steps, max(0, steps - self.props.depth))
         return noise + sum(pyramid_steps[skip:])
 
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
         if self.props.static and self._static_pyramid is not None:
             noise = self._randn() + self._static_pyramid
         else:
@@ -217,8 +217,7 @@ class BrownianProps(TensorNoiseProps):
 
 @dataclass
 class Brownian(TensorNoiseCommon[BrownianProps]):
-    """Uses torchsde.BrownianInterval to generate noise along a fixed timestep.
-    generate() will raise StopIteration at the end of the ramp."""
+    """Uses torchsde.BrownianInterval to generate noise deterministically over Step"""
 
     def __post_init__(self) -> None:
         import torchsde
@@ -236,7 +235,9 @@ class Brownian(TensorNoiseCommon[BrownianProps]):
             cache_size=round(math.log2(self.props.max_steps * 10) * 1.3),  # binary for halfway + 30%
         )
 
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
+        if not step:
+            return self._randn()
         step = step.normal().clamp()
         return self._tree(*step) / math.sqrt(step.distance())  # pyright: ignore[reportOperatorIssue]
 
@@ -258,7 +259,7 @@ class BatchTensorNoise[T: TensorNoiseProps | None](SkrampleTensorNoise):
 
     generators: list[TensorNoiseCommon[T]]
 
-    def generate(self, step: Step) -> torch.Tensor:
+    def generate(self, step: Step | None) -> torch.Tensor:
         return torch.stack([g.generate(step) for g in self.generators])
 
     @classmethod

--- a/skrample/pytorch/noise.py
+++ b/skrample/pytorch/noise.py
@@ -207,8 +207,16 @@ class Pyramid(TensorNoiseCommon[PyramidProps]):
         return noise / noise.std()  # Scaled back to roughly unit variance
 
 
+@dataclass(frozen=True)
+class BrownianProps(TensorNoiseProps):
+    max_steps: int = 10_000
+    """Target resolution of the brownian tree.
+    DT sizes below 1/max_steps run the risk of failing to generate.
+    Increasing this negatively impacts performance."""
+
+
 @dataclass
-class Brownian(TensorNoiseCommon[None]):
+class Brownian(TensorNoiseCommon[BrownianProps]):
     """Uses torchsde.BrownianInterval to generate noise along a fixed timestep.
     generate() will raise StopIteration at the end of the ramp."""
 
@@ -216,13 +224,16 @@ class Brownian(TensorNoiseCommon[None]):
         import torchsde
 
         self._tree = torchsde.BrownianInterval(
+            t0=0,
+            t1=1,
             size=self.shape,
             entropy=self.seed.initial_seed(),
             dtype=self.dtype,
             device=self.seed.device,
             halfway_tree=True,
-            tol=1e-8,
-            pool_size=64,  # tolerance is 99% of the perf hit at this size
+            tol=1 / (self.props.max_steps * 10),  # 1 order of magnitude more than min step size
+            pool_size=2**6,  # tolerance is 99% of the perf hit at this size
+            cache_size=round(math.log2(self.props.max_steps * 10) * 1.3),  # binary for halfway + 30%
         )
 
     def generate(self, step: Step) -> torch.Tensor:
@@ -234,7 +245,7 @@ class Brownian(TensorNoiseCommon[None]):
         cls,
         shape: tuple[int, ...],
         seed: torch.Generator,
-        props: None = None,
+        props: BrownianProps = BrownianProps(),
         dtype: torch.dtype = torch.float32,
     ) -> Self:
         return cls(shape=shape, seed=seed, dtype=dtype, props=props)

--- a/skrample/pytorch/noise.py
+++ b/skrample/pytorch/noise.py
@@ -3,13 +3,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Self
 
-import numpy as np
 import torch
-from numpy.typing import NDArray
 
-
-def schedule_to_ramp(schedule: NDArray[np.float64]) -> NDArray[np.float64]:
-    return np.concatenate([schedule[:, 1], [0]])
+from skrample.common import Step
 
 
 @dataclass(frozen=True)
@@ -21,7 +17,7 @@ class TensorNoiseProps:
 @dataclass
 class SkrampleTensorNoise(ABC):
     @abstractmethod
-    def generate(self) -> torch.Tensor:
+    def generate(self, step: Step) -> torch.Tensor:
         """Next noise tensor in the sequence.
         May raise an exception if at the end of sequence.
         Should be assumed to be stateful, and not used for multiple jobs"""
@@ -53,7 +49,6 @@ class TensorNoiseCommon[T: TensorNoiseProps | None](SkrampleTensorNoise):
         seed: torch.Generator,
         props: T = None,  # ty: ignore # is ABC
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 2, dtype=np.float64),
     ) -> Self:
         """Create the noise agnostically from common inputs typically available during inference.
         It is strongly recommended to set `ramp` to the sigma/noise schedule if available."""
@@ -72,11 +67,10 @@ class Random(TensorNoiseCommon[None]):
         seed: torch.Generator,
         props: None = None,
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 2, dtype=np.float64),
     ) -> Self:
         return cls(shape, seed, dtype, props)
 
-    def generate(self) -> torch.Tensor:
+    def generate(self, step: Step) -> torch.Tensor:
         return self._randn()
 
 
@@ -98,7 +92,6 @@ class Offset(TensorNoiseCommon[OffsetProps]):
         seed: torch.Generator,
         props: OffsetProps = OffsetProps(),
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 2, dtype=np.float64),
     ) -> Self:
         return cls(shape, seed, dtype, props)
 
@@ -112,7 +105,7 @@ class Offset(TensorNoiseCommon[OffsetProps]):
         shape = tuple([d if n in self.props.dims else 1 for n, d in enumerate(self.shape)])
         return self._randn(shape) * self.props.strength**2
 
-    def generate(self) -> torch.Tensor:
+    def generate(self, step: Step) -> torch.Tensor:
         if self.props.static and self.static_offset is not None:
             offset = self.static_offset
         else:
@@ -147,7 +140,6 @@ class Pyramid(TensorNoiseCommon[PyramidProps]):
         seed: torch.Generator,
         props: PyramidProps = PyramidProps(),
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 2, dtype=np.float64),
     ) -> Self:
         return cls(shape, seed, dtype, props)
 
@@ -207,7 +199,7 @@ class Pyramid(TensorNoiseCommon[PyramidProps]):
         skip = min(steps, max(0, steps - self.props.depth))
         return noise + sum(pyramid_steps[skip:])
 
-    def generate(self) -> torch.Tensor:
+    def generate(self, step: Step) -> torch.Tensor:
         if self.props.static and self._static_pyramid is not None:
             noise = self._randn() + self._static_pyramid
         else:
@@ -220,14 +212,8 @@ class Brownian(TensorNoiseCommon[None]):
     """Uses torchsde.BrownianInterval to generate noise along a fixed timestep.
     generate() will raise StopIteration at the end of the ramp."""
 
-    ramp: NDArray[np.float64]
-
     def __post_init__(self) -> None:
         import torchsde
-
-        if len(self.ramp) < 2:
-            err = "Brownian.ramp must have at least two positions"
-            raise ValueError(err)
 
         self._tree = torchsde.BrownianInterval(
             size=self.shape,
@@ -239,23 +225,9 @@ class Brownian(TensorNoiseCommon[None]):
             pool_size=64,  # tolerance is 99% of the perf hit at this size
         )
 
-        self._step: int = 0
-
-        # Basic sanitization to normalize 0->1
-        if self.ramp[0] > self.ramp[-1]:
-            self.ramp = -self.ramp
-        self.ramp -= self.ramp.min()
-        self.ramp /= self.ramp.max()
-
-    def generate(self) -> torch.Tensor:
-        if self._step + 1 >= len(self.ramp):
-            raise StopIteration
-
-        sigma = self.ramp[self._step]
-        sigma_next = self.ramp[self._step + 1]
-        self._step += 1
-
-        return self._tree(sigma, sigma_next) / abs(sigma_next - sigma) ** 0.5
+    def generate(self, step: Step) -> torch.Tensor:
+        step = step.normal().clamp()
+        return self._tree(*step) / math.sqrt(step.distance())  # pyright: ignore[reportOperatorIssue]
 
     @classmethod
     def from_inputs(
@@ -264,9 +236,8 @@ class Brownian(TensorNoiseCommon[None]):
         seed: torch.Generator,
         props: None = None,
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 1000, dtype=np.float64),
     ) -> Self:
-        return cls(shape=shape, seed=seed, ramp=ramp, dtype=dtype, props=props)
+        return cls(shape=shape, seed=seed, dtype=dtype, props=props)
 
 
 @dataclass
@@ -276,8 +247,8 @@ class BatchTensorNoise[T: TensorNoiseProps | None](SkrampleTensorNoise):
 
     generators: list[TensorNoiseCommon[T]]
 
-    def generate(self) -> torch.Tensor:
-        return torch.stack([g.generate() for g in self.generators])
+    def generate(self, step: Step) -> torch.Tensor:
+        return torch.stack([g.generate(step) for g in self.generators])
 
     @classmethod
     def from_batch_inputs[U: TensorNoiseProps | None](  # pyright fails if you use the outer generic
@@ -287,20 +258,14 @@ class BatchTensorNoise[T: TensorNoiseProps | None](SkrampleTensorNoise):
         seeds: list[torch.Generator],
         props: U | None = None,
         dtype: torch.dtype = torch.float32,
-        ramp: NDArray[np.float64] = np.linspace(0, 1, 2, dtype=np.float64),
     ) -> "BatchTensorNoise[U]":
         """Batched equivalent of TensorNoiseCommon.from_inputs
         `unit_shape` is the shape per batch, which means the final result will be size [len(seeds), *unit_shape]"""
         return cls(  # ty: ignore  # Safe from ABC
             [
-                subclass.from_inputs(unit_shape, seed, props, dtype, ramp)
+                subclass.from_inputs(unit_shape, seed, props, dtype)
                 if props is not None
-                else subclass.from_inputs(
-                    unit_shape,
-                    seed,
-                    dtype=dtype,
-                    ramp=ramp,
-                )  # pyright: ignore  # Safe from ABC
+                else subclass.from_inputs(unit_shape, seed, dtype=dtype)  # pyright: ignore  # Safe from ABC
                 for seed in seeds
             ]
         )

--- a/skrample/sampling/functional.py
+++ b/skrample/sampling/functional.py
@@ -129,11 +129,11 @@ class FunctionalSampler(ABC, traits.SamplingCommon):
         rather than being pre-added to the initial value"""
 
         if initial is None and include.start is None:  # Short circuit for common case
-            sample: T = rng()
+            sample: T = rng(None)
         else:
             sample: T = self.add_noise(  # type: ignore # 0 should be valid here because it's added to RNG so it becomes T
                 0 if initial is None else initial,
-                rng(),
+                rng(None),
                 schedule.ipoint((include.start or 0) / steps),
             ) / self.add_noise(0.0, 1.0, schedule.ipoint(0))
             # Rescale sample by initial sigma. Mostly just to handle quirks with Scaled
@@ -250,7 +250,7 @@ class RKUltra(FunctionalUnified, FunctionalSinglestep):
             schedule,
             step,
             self.derivative_transform,
-            rng() if rng else None,
+            rng(step) if rng else None,
             self.stochasticity,
         )[0]
 
@@ -331,7 +331,7 @@ class DynasauRK(FunctionalUnified, FunctionalSinglestep):
             schedule,
             step,
             self.derivative_transform,
-            rng() if rng else None,
+            rng(step) if rng else None,
             self.stochasticity,
         )[0]
 

--- a/skrample/sampling/interface.py
+++ b/skrample/sampling/interface.py
@@ -39,8 +39,8 @@ class StructuredFunctionalAdapter(functional.FunctionalSampler):
                 structured.SampleInput(
                     sample=sample,
                     prediction=model(self.sampler.scale_input(sample, point), *point),
-                    step=Step.from_int(n, len(points)),
-                    noise=rng() if rng and self.sampler.require_noise else None,
+                    step=(step := Step.from_int(n, len(points))),
+                    noise=rng(step) if rng and self.sampler.require_noise else None,
                 ),
                 model_transform,
                 schedule,

--- a/tests/diffusers_samplers.py
+++ b/tests/diffusers_samplers.py
@@ -287,7 +287,7 @@ def test_heun(
         lambda x, t, s, a: fake_model(x),
         model_transform,
         skrample_schedule,
-        lambda: torch.randn(sk_sample.shape, generator=seed, dtype=sk_sample.dtype),
+        lambda _: torch.randn(sk_sample.shape, generator=seed, dtype=sk_sample.dtype),
         steps,
         initial=sk_sample,
     )

--- a/tests/self_sampling.py
+++ b/tests/self_sampling.py
@@ -44,7 +44,7 @@ def capture(
         lambda x, t, s, a: x - math.sin(t),
         model,
         scheduling.Hyper(schedule),
-        random.random,
+        lambda _: random.random(),
         MEASURED_STEPS,
         callback=lambda x, i, d: samples.append(x),
     )
@@ -361,9 +361,9 @@ def test_maruyama(model: type[models.DiffusionModel], schedule: scheduling.Skram
     data_init = 1 / (random.random() + 1e-4) * (random.randint(0, 1) * 2 - 1)
 
     random.seed(0)
-    data_dpm = dpm.sample_model(data_init, fake_model_dpm, model(), schedule, steps, rng=random.random)
+    data_dpm = dpm.sample_model(data_init, fake_model_dpm, model(), schedule, steps, rng=lambda _: random.random())
     random.seed(0)
-    data_maru = maru.sample_model(data_init, fake_model_maru, model(), schedule, steps, rng=random.random)
+    data_maru = maru.sample_model(data_init, fake_model_maru, model(), schedule, steps, rng=lambda _: random.random())
 
     for sample_dpm, sample_maru in zip(samples_dpm, samples_maru, strict=True):
         assert abs(sample_dpm - sample_maru) < 1e-12

--- a/tests/self_sampling.py
+++ b/tests/self_sampling.py
@@ -391,7 +391,7 @@ def test_functional_adapter(
 
     rng = iter(noise)
     model_transform = models.FlowModel()
-    sample_f = adapter.sample_model(sample, fake_model, model_transform, schedule, steps, rng=lambda: next(rng))
+    sample_f = adapter.sample_model(sample, fake_model, model_transform, schedule, steps, rng=lambda _: next(rng))
 
     rng = iter(noise)
     float_schedule = schedule.schedule(steps)
@@ -470,7 +470,7 @@ def test_runge_kutta_diffusers(
         data_init,
         fake_model_ref,
         steps,
-        rng=lambda: torch.randn([1], generator=generator_rng).item(),
+        rng=lambda _: torch.randn([1], generator=generator_rng).item(),
     )
 
     sampler_wrap.set_timesteps(steps)
@@ -534,7 +534,6 @@ def test_diffusers_brownian(
     assert len(wrapper._noise_generator.generators) == 1
     brownian = wrapper._noise_generator.generators[0]
     assert isinstance(brownian, Brownian)
-    assert brownian._step == len(brownian.ramp) - 1
 
 
 @pytest.mark.parametrize(
@@ -579,7 +578,6 @@ def test_rku_brownian(
     assert len(wrapper._noise_generator.generators) == 1
     brownian = wrapper._noise_generator.generators[0]
     assert isinstance(brownian, Brownian)
-    assert brownian._step == len(brownian.ramp) - 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Changes RNG() signature to Step | None to accommodate both deterministic and pure random samplers. Currently everything except Brownian just ignores it. In the future it might be feasible to integrate Brownian on the TensorNoiseCommon class itself have a universal `ancestral` flag to control endpoint determinism, but for now this is an easy adjustment with good benefits.

Additionally optimizes Brownian tree with customizable max steps, default 10k. Should have significantly less performance and memory overhead vs master with about equivalent quality.